### PR TITLE
Allows support to bucket names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.47.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca49303c05d2a740b8a4552fac63a4db6ead84f7e7eeed04761fd3014c26f25"
+checksum = "00a545b16c05af9302b0b4b38a7584f6f323749e407169aa3e9b210e7c0a808d"
 dependencies = [
  "ahash",
  "aws-credential-types",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e2735d2ab28b35ecbb5496c9d41857f52a0d6a0075bbf6a8af306045ea6f6"
+checksum = "99c56bcd6a56cab7933980a54148b476a5a69a7694e3874d9aa2a566f150447d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -813,6 +813,7 @@ dependencies = [
  "bytestring",
  "clap",
  "clap-verbosity-flag",
+ "ethers",
  "fendermint_actor_machine",
  "fendermint_actor_objectstore",
  "fendermint_crypto",
@@ -825,6 +826,7 @@ dependencies = [
  "hoku_signer",
  "homedir",
  "hyper-util",
+ "ipc-api",
  "md-5",
  "mime",
  "once_cell",
@@ -1219,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
@@ -1287,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1307,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2754,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_accumulator"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -2773,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_eam"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -2794,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_machine"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "fil_actor_adm",
@@ -2809,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_objectstore"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -2828,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "fendermint_crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2840,7 +2842,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_actor_interface"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -2868,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_core"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "cid",
  "fnv",
@@ -2882,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_encoding"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -2895,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_genesis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "fendermint_actor_eam",
@@ -2913,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_message"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -2964,7 +2966,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "fil_actor_adm"
 version = "12.0.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -2984,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "12.0.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -3005,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "12.0.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding",
@@ -3018,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "12.0.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3970,7 +3972,7 @@ checksum = "3688e69b38018fec1557254f64c8dc2cc8ec502890182f395dbb0aa997aa5735"
 [[package]]
 name = "hoku_provider"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/rust-hoku.git#c6f147b35f5cd6642af8b44a75da086e84d016b1"
+source = "git+ssh://git@github.com/hokunet/rust-hoku.git#f20913212d23aec98861594e4e9b22dd2a67061c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4001,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "hoku_sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/rust-hoku.git#c6f147b35f5cd6642af8b44a75da086e84d016b1"
+source = "git+ssh://git@github.com/hokunet/rust-hoku.git#f20913212d23aec98861594e4e9b22dd2a67061c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4043,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "hoku_signer"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/rust-hoku.git#c6f147b35f5cd6642af8b44a75da086e84d016b1"
+source = "git+ssh://git@github.com/hokunet/rust-hoku.git#f20913212d23aec98861594e4e9b22dd2a67061c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4267,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
@@ -4327,7 +4329,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -4508,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "ipc-api"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -4536,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "ipc-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -4560,7 +4562,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "ethers",
@@ -5305,7 +5307,7 @@ dependencies = [
 [[package]]
 name = "merkle-tree-rs"
 version = "0.1.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "ethers",
@@ -7154,7 +7156,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -9463,7 +9465,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+ssh://git@github.com/hokunet/ipc.git#9cc36442adc1f84e707764f97548db8b57204e60"
+source = "git+ssh://git@github.com/hokunet/ipc.git#0562a41607ec700436b054a8deb962ac0e82f0f3"
 dependencies = [
  "anyhow",
  "cid",
@@ -9735,15 +9737,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/lib/basin_s3/Cargo.toml
+++ b/lib/basin_s3/Cargo.toml
@@ -42,13 +42,19 @@ tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", optional = true, features = ["env-filter", "time"] }
 uuid = { version = "1.4.1", features = ["v4"] }
-
 anyhow = "1.0.80"
+bytestring = "1.3.1"
+async-tempfile = "0.5.0"
+tempfile = "3.10.1"
+homedir = "0.3.3"
+clap-verbosity-flag = "2.2.1"
+ethers = "2.0.14"
 
 fvm_shared = "4.1.0"
 hoku_sdk = { git = "ssh://git@github.com/hokunet/rust-hoku.git" }
 hoku_provider = { git = "ssh://git@github.com/hokunet/rust-hoku.git"}
 hoku_signer = { git = "ssh://git@github.com/hokunet/rust-hoku.git"}
+ipc-api = { git = "ssh://git@github.com/hokunet/ipc.git" }
 fendermint_vm_message = { git = "ssh://git@github.com/hokunet/ipc.git"}
 fendermint_actor_machine = { git = "ssh://git@github.com/hokunet/ipc.git" }
 fendermint_actor_objectstore = { git = "ssh://git@github.com/hokunet/ipc.git"}
@@ -58,11 +64,7 @@ tendermint-rpc = { version = "0.31.1", features = [
     "http-client",
     "websocket-client",
 ] }
-bytestring = "1.3.1"
-async-tempfile = "0.5.0"
-tempfile = "3.10.1"
-homedir = "0.3.3"
-clap-verbosity-flag = "2.2.1"
+
 
 [dev-dependencies]
 anyhow = { version = "1.0.73", features = ["backtrace"] }

--- a/lib/basin_s3/src/bucket.rs
+++ b/lib/basin_s3/src/bucket.rs
@@ -1,0 +1,97 @@
+use bytestring::ByteString;
+use fvm_shared::address::Address;
+use ipc_api::ethers_address_to_fil_address;
+use s3s::dto::BucketName;
+use s3s::{s3_error, S3Error, S3ErrorCode};
+use std::str::FromStr;
+
+pub struct BucketNameWithOwner {
+    name: String,
+    owner: Address,
+}
+
+impl BucketNameWithOwner {
+    pub fn from(bucket_name: BucketName) -> Result<Self, S3Error> {
+        let parts = bucket_name.split(".").collect::<Vec<&str>>();
+
+        if parts.len() <= 1 {
+            return Err(s3_error!(InvalidBucketName));
+        }
+
+        let addr = ethers::types::Address::from_str(parts[0])
+            .map_err(|e| S3Error::new(S3ErrorCode::Custom(ByteString::from(e.to_string()))))?;
+        let owner = ethers_address_to_fil_address(&addr)
+            .map_err(|e| S3Error::new(S3ErrorCode::Custom(ByteString::from(e.to_string()))))?;
+
+        let name = parts[1..].join(".");
+        if !check_bucket_name(name.as_str()) {
+            return Err(s3_error!(InvalidBucketName));
+        }
+        Ok(Self { name, owner })
+    }
+
+    pub fn owner(&self) -> Address {
+        self.owner
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+pub fn check_bucket_name(name: &str) -> bool {
+    if !(3_usize..=20).contains(&name.len()) {
+        return false;
+    }
+
+    if !name
+        .as_bytes()
+        .iter()
+        .all(|&b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'.' || b == b'-')
+    {
+        return false;
+    }
+
+    let Some(true) = name
+        .as_bytes()
+        .first()
+        .map(|&b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    else {
+        return false;
+    };
+
+    let Some(true) = name
+        .as_bytes()
+        .last()
+        .map(|&b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    else {
+        return false;
+    };
+
+    if name.contains("..") {
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bucket::BucketNameWithOwner;
+    #[test]
+    fn test_bucket_name_with_owner() {
+        let bucket = BucketNameWithOwner::from(
+            "0xe1209fb9aa2d08c8541297ec06ee6bbb63b10edc.foo.bar".to_string(),
+        )
+        .unwrap();
+        assert_eq!("foo.bar", bucket.name());
+
+        let res =
+            BucketNameWithOwner::from("0xe1209fb9aa2d08c8541297ec06ee6bbb63b10edc".to_string());
+        assert!(res.is_err());
+
+        let res =
+            BucketNameWithOwner::from("0xe1209fb9aa2d08c8541297ec06ee6bbb63b10edc.".to_string());
+        assert!(res.is_err());
+    }
+}

--- a/lib/basin_s3/src/lib.rs
+++ b/lib/basin_s3/src/lib.rs
@@ -18,5 +18,6 @@ pub use self::error::*;
 mod error;
 
 mod basin;
+mod bucket;
 mod s3;
 mod utils;

--- a/lib/basin_s3/tests/it_basin.rs
+++ b/lib/basin_s3/tests/it_basin.rs
@@ -3,41 +3,44 @@
     clippy::all, //
     clippy::must_use_candidate, //
 )]
-
-use hoku_provider::json_rpc::JsonRpcProvider;
-use hoku_sdk::network::Network;
-
-use basin_s3::Basin;
-use hoku_signer::key::parse_secret_key;
-use hoku_signer::AccountKind;
-use hoku_signer::Wallet;
-use s3s::auth::SimpleAuth;
-use s3s::service::S3ServiceBuilder;
-use tempfile::tempdir;
-use tokio::sync::OnceCell;
-
-use std::env;
-
+use anyhow::Result;
 use aws_config::SdkConfig;
 use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_sdk_s3::config::Credentials;
 use aws_sdk_s3::config::Region;
 use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_s3::Client;
-
+use aws_sdk_s3::types::error::BucketAlreadyExists;
 use aws_sdk_s3::types::BucketLocationConstraint;
 use aws_sdk_s3::types::CompletedMultipartUpload;
 use aws_sdk_s3::types::CompletedPart;
 use aws_sdk_s3::types::CreateBucketConfiguration;
-
-use anyhow::Result;
+use aws_sdk_s3::Client;
+use basin_s3::Basin;
+use ethers::utils::hex::ToHexExt;
+use hoku_provider::json_rpc::JsonRpcProvider;
+use hoku_sdk::network::Network;
+use hoku_signer::key::parse_secret_key;
+use hoku_signer::AccountKind;
+use hoku_signer::Signer;
+use hoku_signer::Wallet;
+use ipc_api::evm::payload_to_evm_address;
 use once_cell::sync::Lazy;
+use s3s::auth::SimpleAuth;
+use s3s::service::S3ServiceBuilder;
+use std::env;
+use tempfile::tempdir;
 use tokio::sync::Mutex;
 use tokio::sync::MutexGuard;
+use tokio::sync::OnceCell;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, error};
 
 const DOMAIN_NAME: &str = "localhost:8014";
+
+struct SdkConfigWithAddress {
+    sdk: SdkConfig,
+    address: String,
+}
 
 fn setup_tracing() {
     use tracing_subscriber::EnvFilter;
@@ -67,11 +70,11 @@ async fn get_wallet() -> Wallet {
     wallet
 }
 
-async fn config() -> &'static SdkConfig {
+async fn config() -> &'static SdkConfigWithAddress {
     static WALLET: OnceCell<Wallet> = OnceCell::const_new();
     let _ = WALLET.get_or_init(get_wallet).await;
 
-    static CONFIG: Lazy<SdkConfig> = Lazy::new(|| {
+    static CONFIG: Lazy<SdkConfigWithAddress> = Lazy::new(|| {
         setup_tracing();
 
         // Fake credentials
@@ -110,12 +113,20 @@ async fn config() -> &'static SdkConfig {
         let client = s3s_aws::Client::from(service.into_shared());
 
         // Setup aws sdk config
-        SdkConfig::builder()
+        let config = SdkConfig::builder()
             .credentials_provider(SharedCredentialsProvider::new(cred))
             .http_client(client)
             .region(Region::new("us-west-2"))
             .endpoint_url(format!("http://{DOMAIN_NAME}"))
-            .build()
+            .build();
+
+        let eth_address =
+            payload_to_evm_address(WALLET.get().unwrap().clone().address().payload()).unwrap();
+
+        SdkConfigWithAddress {
+            sdk: config,
+            address: eth_address.encode_hex_with_prefix(),
+        }
     });
     &CONFIG
 }
@@ -125,7 +136,7 @@ async fn serial() -> MutexGuard<'static, ()> {
     LOCK.lock().await
 }
 
-async fn create_bucket(c: &Client) -> Result<String> {
+async fn create_bucket(c: &Client, bucket: &str) -> Result<()> {
     let location = BucketLocationConstraint::UsWest2;
     let cfg = CreateBucketConfiguration::builder()
         .location_constraint(location)
@@ -133,18 +144,11 @@ async fn create_bucket(c: &Client) -> Result<String> {
 
     c.create_bucket()
         .create_bucket_configuration(cfg)
-        .bucket("foo")
+        .bucket(bucket)
         .send()
         .await?;
 
-    let list_buckets_output = c.list_buckets().send().await?;
-
-    let mut buckets = list_buckets_output.buckets.unwrap();
-    buckets.sort_by(|a, b| a.creation_date.unwrap().cmp(&b.creation_date.unwrap()));
-    let bucket_name = buckets.last().unwrap().clone().name.unwrap();
-
-    debug!("created bucket: {bucket_name:?}");
-    Ok(bucket_name)
+    Ok(())
 }
 
 async fn delete_object(c: &Client, bucket: &String, key: &str) -> Result<()> {
@@ -169,13 +173,41 @@ macro_rules! log_and_unwrap {
 
 #[tokio::test]
 #[tracing::instrument]
+async fn test_bucket_exists() -> Result<()> {
+    let config = config().await;
+    let c = Client::new(&config.sdk);
+
+    let bucket_str = "test-bucket-exists";
+
+    create_bucket(&c, bucket_str).await?;
+
+    assert!(create_bucket(&c, bucket_str)
+        .await
+        .err()
+        .unwrap()
+        .source()
+        .unwrap()
+        .source()
+        .unwrap()
+        .downcast_ref::<BucketAlreadyExists>()
+        .is_some());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing::instrument]
 async fn test_list_buckets() -> Result<()> {
-    let c = Client::new(config().await);
+    let config = config().await;
+    let c = Client::new(&config.sdk);
     let response1 = log_and_unwrap!(c.list_buckets().send().await);
     drop(response1);
 
-    let bucket1_str = create_bucket(&c).await?;
-    let bucket2_str = create_bucket(&c).await?;
+    let bucket1_str = "test-list-buckets-1";
+    let bucket2_str = "test-list-buckets-2";
+
+    create_bucket(&c, bucket1_str).await?;
+    create_bucket(&c, bucket2_str).await?;
 
     let response2 = log_and_unwrap!(c.list_buckets().send().await);
     let bucket_names: Vec<_> = response2
@@ -183,8 +215,8 @@ async fn test_list_buckets() -> Result<()> {
         .iter()
         .filter_map(|bucket| bucket.name())
         .collect();
-    assert!(bucket_names.contains(&bucket1_str.as_str()));
-    assert!(bucket_names.contains(&bucket2_str.as_str()));
+    assert!(bucket_names.contains(&bucket1_str));
+    assert!(bucket_names.contains(&bucket2_str));
 
     Ok(())
 }
@@ -192,8 +224,13 @@ async fn test_list_buckets() -> Result<()> {
 #[tokio::test]
 #[tracing::instrument]
 async fn test_list_objects_v2() -> Result<()> {
-    let c = Client::new(config().await);
-    let bucket_str = create_bucket(&c).await?;
+    let config = config().await;
+    let c = Client::new(&config.sdk);
+
+    let bucket = "test-list-objects";
+    let bucket_with_owner = format!("{}.{}", &config.address, bucket);
+
+    create_bucket(&c, bucket).await?;
 
     let test_prefix = "this/is/a/test/path/";
     let key1 = "this/is/a/test/path/file1.txt";
@@ -201,13 +238,13 @@ async fn test_list_objects_v2() -> Result<()> {
     {
         let content = "hello world\nनमस्ते दुनिया\n";
         c.put_object()
-            .bucket(&bucket_str)
+            .bucket(&bucket_with_owner)
             .key(key1)
             .body(ByteStream::from_static(content.as_bytes()))
             .send()
             .await?;
         c.put_object()
-            .bucket(&bucket_str)
+            .bucket(&bucket_with_owner)
             .key(key2)
             .body(ByteStream::from_static(content.as_bytes()))
             .send()
@@ -216,7 +253,7 @@ async fn test_list_objects_v2() -> Result<()> {
 
     let result = c
         .list_objects_v2()
-        .bucket(bucket_str)
+        .bucket(&bucket_with_owner)
         .prefix(test_prefix)
         .send()
         .await;
@@ -239,17 +276,20 @@ async fn test_list_objects_v2() -> Result<()> {
 #[tracing::instrument]
 async fn test_single_object() -> Result<()> {
     let _guard = serial().await;
+    let config = config().await;
+    let c = Client::new(&config.sdk);
 
-    let c = Client::new(config().await);
+    let bucket = "test-single-object";
+    let bucket_with_owner = format!("{}.{}", &config.address, bucket);
+
     let key = "sample.txt";
     let content = "hello world\n你好世界\n"; // md5 = 4a944a9af55168f2e2063907c421b061
 
-    let bucket = create_bucket(&c).await?;
-
+    create_bucket(&c, bucket).await?;
     {
         let body = ByteStream::from_static(content.as_bytes());
         c.put_object()
-            .bucket(&bucket)
+            .bucket(&bucket_with_owner)
             .key(key)
             .body(body)
             .send()
@@ -259,7 +299,12 @@ async fn test_single_object() -> Result<()> {
     sleep(Duration::from_millis(2000)).await;
 
     {
-        let ans = c.get_object().bucket(&bucket).key(key).send().await?;
+        let ans = c
+            .get_object()
+            .bucket(&bucket_with_owner)
+            .key(key)
+            .send()
+            .await?;
 
         let content_length: usize = ans.content_length().unwrap().try_into().unwrap();
         let e_tag = ans.e_tag.unwrap();
@@ -269,9 +314,8 @@ async fn test_single_object() -> Result<()> {
         assert_eq!(e_tag, "\"4a944a9af55168f2e2063907c421b061\"".to_string());
         assert_eq!(body.as_ref(), content.as_bytes());
     }
-
     {
-        delete_object(&c, &bucket, key).await?;
+        delete_object(&c, &bucket_with_owner, key).await?;
         //delete_bucket(&c, bucket).await?;
     }
 
@@ -283,9 +327,13 @@ async fn test_single_object() -> Result<()> {
 async fn test_multipart() -> Result<()> {
     let _guard = serial().await;
 
-    let c = Client::new(config().await);
+    let config = config().await;
+    let c = Client::new(&config.sdk);
 
-    let bucket = create_bucket(&c).await?;
+    let bucket = "test-multipart";
+    let bucket_with_owner = format!("{}.{}", &config.address, bucket);
+
+    create_bucket(&c, bucket).await?;
 
     let key = "sample-test.txt";
     let content = "abcdefghijklmnopqrstuvwxyz/0123456789/!@#$%^&*();\n";
@@ -293,7 +341,7 @@ async fn test_multipart() -> Result<()> {
     let upload_id = {
         let ans = c
             .create_multipart_upload()
-            .bucket(&bucket)
+            .bucket(&bucket_with_owner)
             .key(key)
             .send()
             .await?;
@@ -307,7 +355,7 @@ async fn test_multipart() -> Result<()> {
 
         let ans = c
             .upload_part()
-            .bucket(&bucket)
+            .bucket(&bucket_with_owner)
             .key(key)
             .upload_id(upload_id)
             .body(body)
@@ -330,7 +378,7 @@ async fn test_multipart() -> Result<()> {
 
         let _ = c
             .complete_multipart_upload()
-            .bucket(&bucket)
+            .bucket(&bucket_with_owner)
             .key(key)
             .multipart_upload(upload)
             .upload_id(upload_id)
@@ -342,7 +390,12 @@ async fn test_multipart() -> Result<()> {
     sleep(Duration::from_millis(2000)).await;
 
     {
-        let ans = c.get_object().bucket(&bucket).key(key).send().await?;
+        let ans = c
+            .get_object()
+            .bucket(&bucket_with_owner)
+            .key(key)
+            .send()
+            .await?;
 
         let content_length: usize = ans.content_length().unwrap().try_into().unwrap();
         let e_tag = ans.e_tag.unwrap();
@@ -354,7 +407,7 @@ async fn test_multipart() -> Result<()> {
     }
 
     {
-        delete_object(&c, &bucket, key).await?;
+        delete_object(&c, &bucket_with_owner, key).await?;
         //delete_bucket(&c, bucket).await?;
     }
 
@@ -366,16 +419,21 @@ async fn test_multipart() -> Result<()> {
 async fn test_copy() -> Result<()> {
     let _guard = serial().await;
 
-    let c = Client::new(config().await);
+    let config = config().await;
+    let c = Client::new(&config.sdk);
+
+    let bucket = "test-copy";
+    let bucket_with_owner = format!("{}.{}", &config.address, bucket);
+
     let key = "sample.txt";
     let content = "hello world\n你好世界\n"; // md5 = 4a944a9af55168f2e2063907c421b061
 
-    let bucket = create_bucket(&c).await?;
+    create_bucket(&c, bucket).await?;
 
     {
         let body = ByteStream::from_static(content.as_bytes());
         c.put_object()
-            .bucket(&bucket)
+            .bucket(&bucket_with_owner)
             .key(key)
             .body(body)
             .send()
@@ -386,9 +444,9 @@ async fn test_copy() -> Result<()> {
 
     {
         c.copy_object()
-            .bucket(&bucket)
+            .bucket(&bucket_with_owner)
             .key("sample-copy.txt")
-            .copy_source(format!("{}/{}", &bucket, &key))
+            .copy_source(format!("{}/{}", &bucket_with_owner, &key))
             .send()
             .await?;
     }
@@ -399,7 +457,7 @@ async fn test_copy() -> Result<()> {
     {
         let ans = c
             .get_object()
-            .bucket(&bucket)
+            .bucket(&bucket_with_owner)
             .key("sample-copy.txt")
             .send()
             .await?;
@@ -414,8 +472,8 @@ async fn test_copy() -> Result<()> {
     }
 
     {
-        delete_object(&c, &bucket, key).await?;
-        delete_object(&c, &bucket, "sample-copy.txt").await?;
+        delete_object(&c, &bucket_with_owner, key).await?;
+        delete_object(&c, &bucket_with_owner, "sample-copy.txt").await?;
         //delete_bucket(&c, bucket).await?;
     }
 


### PR DESCRIPTION
# Summary

Closes #8 

# Demo

A quick video showing the feature through the lens of the minio client
https://www.loom.com/share/43a2a2d9252541089c627f425f752967?sid=b3432758-64f1-4ad2-a0de-fbd279c95def

# Implementation details
- A new metadata is added as part of the bucket's metadata to store the bucket's name
- A helper method (`get_bucket_address_by_alias`) is created to fetch the bucket's address given `{owner_eth_address}.{bucket_name}`
- The `created_bucket` is refactored to check if that is name is already taken and to add the metadata
- The methods `complete_multipart_upload`, `copy_object`, `delete_object`, `delete_objects`, `get_object`, `head_bucket`, `head_object`, `list_objects_v2`, and `put_object` are refactored to use the helper method (`get_bucket_address_by_alias`)
- Refactored the tests to fit into the new feature

# Review orientation

- Check out the video above and make sure you understand the feature
- Check out the [discussion](https://www.notion.so/Referencing-buckets-by-name-5f069599584041d187d76b9a906847e6?d=d9e8f257091d4d9c9ef5b09b0de47e72) to understand the paths that were tried and how we landed in this implementation
- Check out the code in the following order
  - Go to the `create_bucket` method and see if the logic is correct
  - Check out the other methods, they should follow a similar pattern described [here](https://github.com/hokunet/basin-s3/pull/9#discussion_r1745939441)
  - Check out the comments I made along the code
- Test it out locally to make sure everything makes sense and works