### PR TITLE
chore: remove ssh handling

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,14 +15,6 @@ jobs:
     name: clippy
     runs-on: self-hosted
     steps:
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-            ssh-private-key: |
-              ${{ secrets.IPC_DEPLOY_KEY }}
-              ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
-              ${{ secrets.RUST_RECALL_DEPLOY_KEY }}
-              ${{ secrets.CONTRACTS_DEPLOY_KEY }}
-
       - name: Checkout source code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   publish:
@@ -32,11 +31,6 @@ jobs:
         # Format the version string as sha-[short-commit-hash].
         VERSION="sha-$COMMIT_HASH"
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-
-    - name: Prepare git and ssh config for build context
-      run: |
-        mkdir root-config
-        cp -r ~/.gitconfig ~/.ssh root-config
 
     - name: Build and push
       uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,14 +15,6 @@ jobs:
     name: Publish
     runs-on: self-hosted
     steps:
-    - uses: webfactory/ssh-agent@v0.9.0
-      with:
-        ssh-private-key: |
-          ${{ secrets.IPC_DEPLOY_KEY }}
-          ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
-          ${{ secrets.RUST_RECALL_DEPLOY_KEY }}
-          ${{ secrets.CONTRACTS_DEPLOY_KEY }}
-
     - name: Checkout source code
       uses: actions/checkout@v4
     - name: Set up Docker Buildx

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,7 +42,6 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        ssh: default=${{ env.SSH_AUTH_SOCK }}
         file: ./ci.Dockerfile
         push: ${{ github.ref == 'refs/heads/main' }}
         tags: textilemachine/recall-s3:latest,textilemachine/recall-s3:${{ steps.prep.outputs.VERSION }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "31c372578ce4215ccf94ec3f3585fbb6a902e47d07b064ff8a55d850ffb5025e"
 dependencies = [
  "parking_lot",
  "pin-project-lite",
- "rustc_version",
+ "rustc_version 0.4.1",
  "smol_str",
  "tokio",
  "tracing",
@@ -102,6 +102,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy-json-abi"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4012581681b186ba0882007ed873987cc37f86b1b488fe6b91d5efd0b585dc41"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478bedf4d24e71ea48428d1bc278553bd7c6ae07c30ca063beb0b09fe58a9e74"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand",
+ "ruint",
+ "rustc-hash",
+ "serde",
+ "sha3",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
+dependencies = [
+ "arrayvec 0.7.6",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2708e27f58d747423ae21d31b7a6625159bd8d867470ddd0256f396a68efa11"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b7984d7e085dec382d2c5ef022b533fcdb1fe6129200af30ebf5afddb6a361"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.7.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d6a9fc4ed1a3c70bdb2357bec3924551c1a59f24e5a04a74472c755b37f87d"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.98",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b3e9a48a6dd7bb052a111c8d93b5afc7956ed5e2cb4177793dc63bb1d2a36"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6044800da35c38118fd4b98e18306bd3b91af5dedeb54c1b768cf1b4fb68f549"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +295,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 dependencies = [
  "backtrace",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -314,7 +560,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -701,7 +947,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "rustc_version",
+ "rustc_version 0.4.1",
  "tracing",
 ]
 
@@ -935,7 +1181,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -943,6 +1198,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1243,7 +1504,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1649,7 +1910,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -1838,7 +2099,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -1995,6 +2256,17 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2630,7 +2902,7 @@ dependencies = [
  "chrono",
  "ethers-core",
  "reqwest 0.11.27",
- "semver",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2740,7 +3012,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "semver",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "solang-parser",
@@ -2860,6 +3132,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec 0.7.6",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec 0.7.6",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "fdlimit"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_blobs_shared"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "data-encoding",
@@ -2888,14 +3182,13 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_bucket"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "blake3",
  "cid",
  "fendermint_actor_blobs_shared",
  "fendermint_actor_machine",
- "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
@@ -2904,13 +3197,14 @@ dependencies = [
  "fvm_shared",
  "num-derive 0.3.3",
  "num-traits",
+ "recall_sol_facade",
  "serde",
 ]
 
 [[package]]
 name = "fendermint_actor_eam"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -2931,24 +3225,23 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_machine"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
+ "anyhow",
  "fil_actor_adm",
- "fil_actors_evm_shared",
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared",
- "multihash",
- "num-traits",
+ "recall_sol_facade",
  "serde",
 ]
 
 [[package]]
 name = "fendermint_actor_recall_config_shared"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "fendermint_actor_blobs_shared",
  "fil_actors_runtime",
@@ -2963,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "fendermint_actor_timehub"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -2977,6 +3270,7 @@ dependencies = [
  "fvm_shared",
  "num-derive 0.3.3",
  "num-traits",
+ "recall_sol_facade",
  "serde",
  "tracing",
 ]
@@ -2984,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "fendermint_crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2996,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "fendermint_eth_api"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3033,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "fendermint_rpc"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3060,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_actor_interface"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -3088,7 +3382,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_core"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "cid",
  "fnv",
@@ -3102,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_encoding"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "cid",
  "fvm_shared",
@@ -3115,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_genesis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "fendermint_actor_eam",
@@ -3133,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "fendermint_vm_message"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -3185,7 +3479,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "fil_actor_adm"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -3205,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -3226,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_evm_shared"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding",
@@ -3239,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "fil_actors_runtime"
 version = "15.0.0-rc1"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3467,8 +3761,8 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "7.0.0"
-source = "git+https://github.com/filecoin-project/actors-utils?rev=0f8365151f44785f7bead4e5500258fd5c8944e6#0f8365151f44785f7bead4e5500258fd5c8944e6"
+version = "8.0.0"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
@@ -3480,8 +3774,8 @@ dependencies = [
 
 [[package]]
 name = "frc42_hasher"
-version = "5.0.0"
-source = "git+https://github.com/filecoin-project/actors-utils?rev=0f8365151f44785f7bead4e5500258fd5c8944e6#0f8365151f44785f7bead4e5500258fd5c8944e6"
+version = "6.0.0"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "fvm_sdk",
  "fvm_shared",
@@ -3490,8 +3784,8 @@ dependencies = [
 
 [[package]]
 name = "frc42_macros"
-version = "5.0.0"
-source = "git+https://github.com/filecoin-project/actors-utils?rev=0f8365151f44785f7bead4e5500258fd5c8944e6#0f8365151f44785f7bead4e5500258fd5c8944e6"
+version = "6.0.0"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -4015,6 +4309,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -4747,6 +5042,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -4817,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "ipc-api"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -4846,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "ipc-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -4870,7 +5166,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "ethers",
@@ -5422,13 +5718,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "ena",
  "itertools 0.11.0",
  "lalrpop-util",
@@ -5703,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "merkle-tree-rs"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "ethers",
@@ -5771,12 +6077,6 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "more-asserts"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "multibase"
@@ -6691,7 +6991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -7122,6 +7422,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7219,6 +7541,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
@@ -7226,6 +7550,8 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.5",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -7441,6 +7767,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -7527,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "recall_ipld"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -7545,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "recall_provider"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/rust-recall.git?rev=1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903#1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903"
+source = "git+https://github.com/recallnet/rust-recall.git?rev=8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11#8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7617,12 +7944,11 @@ dependencies = [
 [[package]]
 name = "recall_sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/rust-recall.git?rev=1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903#1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903"
+source = "git+https://github.com/recallnet/rust-recall.git?rev=8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11#8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11"
 dependencies = [
  "anyhow",
  "async-tempfile",
  "async-trait",
- "base64 0.22.1",
  "bytes",
  "cid",
  "console",
@@ -7640,7 +7966,6 @@ dependencies = [
  "ipc_actors_abis",
  "iroh",
  "lazy_static",
- "more-asserts",
  "num-traits",
  "peekable",
  "rand",
@@ -7657,7 +7982,7 @@ dependencies = [
 [[package]]
 name = "recall_signer"
 version = "0.1.0"
-source = "git+ssh://git@github.com/recallnet/rust-recall.git?rev=1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903#1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903"
+source = "git+https://github.com/recallnet/rust-recall.git?rev=8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11#8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7670,6 +7995,31 @@ dependencies = [
  "recall_provider",
  "tendermint-rpc",
  "tokio",
+]
+
+[[package]]
+name = "recall_sol_facade"
+version = "0.1.0"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "alloy-sol-types",
+ "anyhow",
+ "dunce",
+ "eyre",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+ "syn 2.0.98",
+ "thiserror 2.0.11",
+ "walkdir",
 ]
 
 [[package]]
@@ -8063,6 +8413,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825df406ec217a8116bd7b06897c6cc8f65ffefc15d030ae2c9540acc9ed50b6"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rust_decimal"
 version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8098,11 +8480,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.25",
 ]
 
 [[package]]
@@ -8296,6 +8687,18 @@ name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -8528,11 +8931,29 @@ checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -8806,6 +9227,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9066,7 +9497,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
- "semver",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -9322,7 +9753,7 @@ dependencies = [
  "hex",
  "once_cell",
  "reqwest 0.11.27",
- "semver",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -9377,6 +9808,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2de690018098e367beeb793991c7d4dc7270f42c9d2ac4ccc876c1368ca430"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9560,7 +10003,7 @@ dependencies = [
  "hyper-rustls 0.22.1",
  "peg",
  "pin-project",
- "semver",
+ "semver 1.0.25",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -10394,7 +10837,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vm_api"
 version = "1.0.0"
-source = "git+ssh://git@github.com/recallnet/ipc.git?rev=65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7#65bf7b81d8c65cf2b324bf4e0ebabb122414e9c7"
+source = "git+https://github.com/recallnet/ipc.git?rev=2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2#2f2f4926bf2db5a96ba2eb5cd34e7bb3689f9ab2"
 dependencies = [
  "anyhow",
  "cid",
@@ -10414,6 +10857,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -11152,7 +11604,7 @@ dependencies = [
  "js-sys",
  "log",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
  "thiserror 1.0.69",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Textile <contact@textile.io"]
-description = "An S3 adapter for Textile IPC Object Storage."
+description = "An S3 adapter for Recall Object Storage."
 edition = "2021"
 homepage = "https://github.com/recallnet/recall-s3/"
 license = "MIT OR Apache-2.0"
 readme = "./README.md"
 repository = "https://github.com/recallnet/recall-s3/"
-keywords = ["s3", "ipc", "filecoin", "tableland"]
+keywords = ["recall", "s3"]
 version = "0.1.0"

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -33,11 +33,6 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
   rustup toolchain install ${RUST_VERSION}-aarch64-unknown-linux-gnu; \
   fi
 
-
-COPY /root-config /root/
-RUN sed -E 's|/home/ghrunner[0-9]?|/root|g' -i.bak /root/.ssh/config
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-
 RUN rm -rf ~/.ssh/known_hosts && \
     umask 077; mkdir -p ~/.ssh && \
     ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -47,7 +42,6 @@ COPY ./Cargo.toml ./Cargo.toml
 COPY ./lib ./lib
 
 RUN \
-  --mount=type=ssh \
   --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
   --mount=type=cache,target=/root/.cargo/git,sharing=locked \
   --mount=type=cache,target=/app/target,sharing=locked \

--- a/lib/recall_s3/Cargo.toml
+++ b/lib/recall_s3/Cargo.toml
@@ -9,7 +9,7 @@ readme = { workspace = true }
 repository = { workspace = true }
 version = { workspace = true }
 categories = ["database"]
-keywords = ["s3", "recall"]
+keywords = ["recall", "s3"]
 
 [[bin]]
 name = "recall_s3"
@@ -52,9 +52,9 @@ tempfile = "3.13.0"
 homedir = "0.3.4"
 clap-verbosity-flag = "2.2.2"
 ethers = "2.0.14"
-recall_sdk = { git = "ssh://git@github.com/recallnet/rust-recall.git", rev = "1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903" }
-recall_provider = { git = "ssh://git@github.com/recallnet/rust-recall.git", rev = "1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903" }
-recall_signer = { git = "ssh://git@github.com/recallnet/rust-recall.git", rev = "1cf1e17ea7ecdb4bf6c589b29b3eb20c74db6903" }
+recall_sdk = { git = "https://github.com/recallnet/rust-recall.git", rev = "8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11" }
+recall_provider = { git = "https://github.com/recallnet/rust-recall.git", rev = "8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11" }
+recall_signer = { git = "https://github.com/recallnet/rust-recall.git", rev = "8d4db6d5d22f5c0a7ed3388ad8b92aa72e0d8f11" }
 prometheus = { version = "0.13", features = ["process"] }
 prometheus_exporter = "0.8"
 lazy_static = "1.5"
@@ -64,7 +64,6 @@ lazy_static = "1.5"
 # depending on the same _without_ the "vendored" feature, because then the Docker build for
 # for ARM64 on AMD64 will fail, it won't find the OpenSSL installation.
 openssl = { version = "0.10", features = ["vendored"] }
-
 
 [dev-dependencies]
 anyhow = { version = "1.0.91", features = ["backtrace"] }

--- a/lib/recall_s3/src/s3.rs
+++ b/lib/recall_s3/src/s3.rs
@@ -193,10 +193,12 @@ where
             .map_err(|e| S3Error::new(S3ErrorCode::Custom(ByteString::from(e.to_string()))))?;
 
         let last_modified = try_!(SystemTime::now().duration_since(UNIX_EPOCH)).as_secs();
+        let address = wallet.address();
         let _ = machine
             .add_from_path(
                 self.provider.deref(),
                 &mut wallet,
+                address,
                 &key,
                 file.file_path(),
                 AddOptions {
@@ -305,10 +307,12 @@ where
             .await
             .map_err(|e| S3Error::new(S3ErrorCode::Custom(ByteString::from(e.to_string()))))?;
 
+        let address = wallet.address();
         let _ = machine
             .add_reader(
                 self.provider.deref(),
                 &mut wallet,
+                address,
                 &dst_key,
                 file,
                 total_size,
@@ -460,11 +464,13 @@ where
             None => unreachable!(),
         };
 
+        let address = wallet.address();
         let key = req.input.key;
         let tx = machine
             .delete(
                 self.provider.deref(),
                 &mut wallet,
+                address,
                 key.as_str(),
                 DeleteOptions::default(),
             )
@@ -503,11 +509,13 @@ where
             Some(w) => w.clone(),
             None => unreachable!(),
         };
+        let address = wallet.address();
         for object in req.input.delete.objects {
             let tx = machine
                 .delete(
                     self.provider.deref(),
                     &mut wallet,
+                    address,
                     object.key.as_str(),
                     DeleteOptions::default(),
                 )
@@ -933,10 +941,12 @@ where
             }
         };
 
+        let address = wallet.address();
         let _tx = machine
             .add_from_path(
                 self.provider.deref(),
                 &mut wallet,
+                address,
                 &key,
                 file.file_path(),
                 AddOptions {


### PR DESCRIPTION
@brunocalza this is failing due to some diff w/ recent SDK, but throwing it up anyway. if GH jobs run using ssh, it messes up the action runner's git config, so wanted to get this up asap.